### PR TITLE
chore: rename workspace from terraform-cloud-google to gcp

### DIFF
--- a/.terraform.lock.hcl
+++ b/.terraform.lock.hcl
@@ -2,7 +2,8 @@
 # Manual edits may be lost in future updates.
 
 provider "registry.terraform.io/hashicorp/google" {
-  version = "7.40.0"
+  version     = "7.40.0"
+  constraints = "~> 7.0"
   hashes = [
     "h1:5dao98iLYK2gKuX3zavy1VOmxyKDYSt8cyXlhsSAmN0=",
     "h1:8ZajDajgFPtlkBQwkbnmy1oK15SbCKisKvqpDh5yYaw=",

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@
 
 Terraform repo managing GCP infrastructure (GCE, firewall, GCS) via Terraform Cloud.
 Flat structure — no modules, no local workspaces, no subdirectories.
-Uses a Terraform Cloud remote workspace (`terraform-cloud-google`).
+Uses a Terraform Cloud remote workspace (`gcp`).
 
 ## Key Versions
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# terraform-cloud-google
+# gcp
 
-[![Codacy Badge](https://api.codacy.com/project/badge/Grade/64d72fc30d204a5bb079f2a6eed57df4)](https://www.codacy.com/manual/ymmmtym/terraform-cloud-google?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=ymmmtym/terraform-cloud-google&amp;utm_campaign=Badge_Grade)
+[![Codacy Badge](https://api.codacy.com/project/badge/Grade/64d72fc30d204a5bb079f2a6eed57df4)](https://www.codacy.com/manual/ymmmtym/gcp?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=ymmmtym/gcp&amp;utm_campaign=Badge_Grade)
 
 ## Usage
 

--- a/main.tf
+++ b/main.tf
@@ -3,7 +3,7 @@ terraform {
     organization = "yumenomatayume"
 
     workspaces {
-      name = "terraform-cloud-google"
+      name = "gcp"
     }
   }
 


### PR DESCRIPTION
Terraform Cloud workspace name を `terraform-cloud-google` から `gcp` にリネームします。

## 変更内容
- `main.tf` — backend workspace name を更新
- `README.md` — タイトル・Codacy バッジ URL を更新
- `AGENTS.md` — ワークスペース参照を更新
- `.terraform.lock.hcl` — pre-commit による再検証

## 前提条件
- [x] Terraform Cloud でワークスペース名を `gcp` に変更済み
- [x] GitHub リポジトリ名を `gcp` に変更済み
- [x] ローカルディレクトリ名を `gcp` に変更済み